### PR TITLE
Remove obsolete vpn DNSRecord from Cloudflare operator manifests

### DIFF
--- a/base/cloudflare-operator/dnsrecord.yaml
+++ b/base/cloudflare-operator/dnsrecord.yaml
@@ -40,19 +40,6 @@ spec:
 apiVersion: cloudflare-operator.io/v1
 kind: DNSRecord
 metadata:
-  name: vpn-${BASE_DOMAIN/./-}-v4
-  namespace: cloudflare-operator
-spec:
-  name: vpn.${BASE_DOMAIN}
-  type: A
-  ipRef:
-    name: ${BASE_DOMAIN/./-}-v4
-  proxied: false
-  ttl: 1
----
-apiVersion: cloudflare-operator.io/v1
-kind: DNSRecord
-metadata:
   name: mail-${BASE_DOMAIN/./-}-v4
   namespace: cloudflare-operator
 spec:


### PR DESCRIPTION
### Motivation
- The environment no longer needs the WireGuard/Tailnet VPN DNS entry, so the managed Cloudflare A record for `vpn.${BASE_DOMAIN}` was removed to avoid a stale DNS record.

### Description
- Removed the `vpn.${BASE_DOMAIN}` A `DNSRecord` resource from `base/cloudflare-operator/dnsrecord.yaml` while keeping the other DNS records and document separators intact.

### Testing
- Ran `rg -n "vpn\\.|vpn-\\$\\{BASE_DOMAIN" base/cloudflare-operator || true` to confirm no remaining vpn entries, which returned no matches.
- Verified the change with `git diff -- base/cloudflare-operator/dnsrecord.yaml` to confirm only the vpn record block was removed.
- Attempted a YAML parse with a short Python script, but the environment lacked `PyYAML` so the parse check could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de414ef62c83288c9b729bd4b8289e)