### PR TITLE
chore(renovate): remove stale metallb custom manager path

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -58,7 +58,6 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/crds\\/metallb\\/crds\\.yaml$/",
         "/crds\\/cloudnative-pg\\/crds\\.yaml$/",
         "/crds\\/cnpg-plugin-barman-cloud\\/crds\\.yaml$/"
       ],


### PR DESCRIPTION
### Motivation
- Remove a stale `crds/metallb/crds.yaml` entry from Renovate custom regex managers to avoid matching non-existent files and spurious updates.

### Description
- Deleted the `"/crds\\/metallb\\/crds\\.yaml$"` entry from the `managerFilePatterns` array of the regex `customManager` in `.github/renovate.json`, leaving the other CRD patterns unchanged.

### Testing
- Validated the file is valid JSON with `python -m json.tool .github/renovate.json` (passed) and ran an automated path-check that reported `crds/metallb/crds.yaml` as missing, confirming the entry was stale.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d1e4bd7c8328af5f6a09f79eb879)