### PR TITLE
plex: disable HTTPRoute timeouts for long streams/downloads

### DIFF
--- a/apps/usenet/plex/httproute.yaml
+++ b/apps/usenet/plex/httproute.yaml
@@ -19,6 +19,9 @@ spec:
         - path:
             type: PathPrefix
             value: /
+      timeouts:
+        request: 0s
+        backendRequest: 0s
       backendRefs:
         - name: plex
           port: 32400


### PR DESCRIPTION
### Motivation
- Prevent Envoy Gateway from terminating long-lived Plex responses which caused media downloads and some third-party streaming clients (e.g. Infuse) to fail.

### Description
- Add `timeouts` to `apps/usenet/plex/httproute.yaml` and set `request: 0s` and `backendRequest: 0s` to disable route-level timeouts for the Plex route.

### Testing
- Verified the YAML change with `git diff` and reviewed the updated file, then committed the change successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f44a6c1808832888b55c3a58acebe4)