### PR TITLE
Move Intel GPU resource from Jellyfin to Plex

### DIFF
--- a/apps/usenet/jellyfin/deployment.yaml
+++ b/apps/usenet/jellyfin/deployment.yaml
@@ -49,10 +49,8 @@ spec:
               name: movies2
           resources:
             requests:
-              gpu.intel.com/i915: 1
               memory: 4Gi
             limits:
-              gpu.intel.com/i915: 1
               memory: 16Gi
           startupProbe:
             httpGet:

--- a/apps/usenet/plex/deployment.yaml
+++ b/apps/usenet/plex/deployment.yaml
@@ -52,8 +52,10 @@ spec:
               name: tmpfs
           resources:
             requests:
+              gpu.intel.com/i915: 1
               memory: 4Gi
             limits:
+              gpu.intel.com/i915: 1
               memory: 16Gi
           startupProbe:
             httpGet:


### PR DESCRIPTION
### Motivation
- Change which media server reserves the Intel GPU so Plex uses the `gpu.intel.com/i915` device for hardware acceleration instead of Jellyfin, while leaving memory requests/limits unchanged.

### Description
- Removed `gpu.intel.com/i915: 1` from `resources.requests` and `resources.limits` in `apps/usenet/jellyfin/deployment.yaml` and added `gpu.intel.com/i915: 1` to `resources.requests` and `resources.limits` in `apps/usenet/plex/deployment.yaml`.

### Testing
- Ran local verification commands `git diff -- apps/usenet/jellyfin/deployment.yaml apps/usenet/plex/deployment.yaml`, `git status --short`, and invoked `make_pr` to produce the PR metadata, and each check showed the expected changes were applied successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11492e72b483289926a747649e12d0)