### PR TITLE
Align TeslaMate image tag with Grafana (4.0.1)

### DIFF
--- a/apps/teslamate/teslamate/deployment.yaml
+++ b/apps/teslamate/teslamate/deployment.yaml
@@ -42,7 +42,7 @@ spec:
               memory: 16Mi
       containers:
         - name: teslamate
-          image: ghcr.io/teslamate-org/teslamate:pr-5406
+          image: ghcr.io/teslamate-org/teslamate:4.0.1
           env:
             - name: DISABLE_MQTT
               value: "true"


### PR DESCRIPTION
### Motivation
- Ensure the TeslaMate backend image uses the same release tag as the bundled Grafana (TeslaMate 4.0.1) to keep component versions consistent.

### Description
- Updated the TeslaMate deployment image in `apps/teslamate/teslamate/deployment.yaml` from `ghcr.io/teslamate-org/teslamate:pr-5406` to `ghcr.io/teslamate-org/teslamate:4.0.1`.

### Testing
- Ran `git diff --check` which passed, and attempted `kubectl kustomize apps/teslamate` but it could not be executed in this environment because `kubectl` is not installed (no kustomize validation performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f1a4e89c88328b86e3e890f1269b3)